### PR TITLE
Check that includes exist in addition to normal modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -18,9 +18,19 @@ module.exports = function(configPath, modulesRoot) {
   var buildConfig = readBuildConfig(configPath);
   var requireConfig = readRequireConfig(buildConfig);
   var config = extend({}, requireConfig, buildConfig);
+  var moduleNames = config.modules.reduce(function(names, module) {
+    names.push(module.name);
 
-  return config.modules.reduce(function(undefinedModules, module) {
-    var name = module.name;
+    if (module.include) {
+      names = module.include.concat(names);
+    }
+
+    return names;
+  }, []);
+
+//  console.warn(names);
+
+  return moduleNames.reduce(function(undefinedModules, name) {
     var resolvedName = path.join(modulesRoot, resolveModuleName(config, name));
 
     if (!checkModuleExists(resolvedName)) {

--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ module.exports = function(configPath, modulesRoot) {
     return names;
   }, []);
 
-//  console.warn(names);
-
   return moduleNames.reduce(function(undefinedModules, name) {
     var resolvedName = path.join(modulesRoot, resolveModuleName(config, name));
 

--- a/index.js
+++ b/index.js
@@ -23,9 +23,10 @@ module.exports = function(configPath, modulesRoot) {
     names.push(module.name);
 
     if (module.include) {
-      names = names.concat(module.include.filter(function(name) {
-        return names.indexOf(name) === -1;
-      }));
+      names = arrayUnion(names, module.include);
+    }
+    if (module.exclude) {
+      names = arrayUnion(names, module.exclude);
     }
 
     return names;
@@ -41,6 +42,12 @@ module.exports = function(configPath, modulesRoot) {
     return undefinedModules;
   }, []);
 };
+
+function arrayUnion(arrA, arrB) {
+  return arrA.concat(arrB.filter(function(item) {
+    return arrA.indexOf(item) === -1;
+  }));
+}
 
 function resolveModuleName(config, requireConfig, moduleName) {
   var splitPath = moduleName.split(path.sep);

--- a/test/fixtures/with-exclude/build.json
+++ b/test/fixtures/with-exclude/build.json
@@ -1,0 +1,9 @@
+{
+  "modules": [{
+    "name": "foo",
+    "exclude": [
+      "jquery",
+      "common"
+    ]
+  }]
+}

--- a/test/fixtures/with-include/build.json
+++ b/test/fixtures/with-include/build.json
@@ -1,0 +1,12 @@
+{
+  "modules": [{
+    "name": "foo"
+  }, {
+    "name": "bar"
+  }, {
+    "name": "common",
+    "include": [
+      "fooMod"
+    ]
+  }]
+}

--- a/test/fixtures/with-slash-path/build.json
+++ b/test/fixtures/with-slash-path/build.json
@@ -1,0 +1,6 @@
+{
+  "modules": [{
+    "name": "foo/bar",
+    "name": "foo/foo"
+  }]
+}

--- a/test/fixtures/with-slash-path/config.js
+++ b/test/fixtures/with-slash-path/config.js
@@ -1,0 +1,7 @@
+requirejs.config({
+  map: {
+    '*': {
+      'foo': 'vendor/foo'
+    }
+  }
+});

--- a/test/index.js
+++ b/test/index.js
@@ -94,6 +94,18 @@ describe('buildLayerLint', function() {
 
       expect(buildLayerLint('build.json')).to.deep.equal([]);
     });
+
+    describe('where paths are relative to a path lookup', function() {
+      it('returns an array of undefined module names', function() {
+        mockFs({
+          'build.json': fs.readFileSync(path.join(fixturePath, 'with-slash-path/build.json')),
+          'config.js': fs.readFileSync(path.join(fixturePath, 'with-slash-path/config.js')),
+          'vendor/foo/bar.js': 'foo',
+        });
+
+        expect(buildLayerLint('build.json')).to.deep.equal(['foo/foo']);
+      });
+    });
   });
 
   describe('given a module root', function() {
@@ -127,28 +139,29 @@ describe('buildLayerLint', function() {
         buildLayerLint('build.json');
       }).to.throw(/no such file or directory/);
     });
-  });
 
-  describe('given a build.json with includes where all includes are not defined', function() {
-    it('returns an array of undefined module names and includes', function() {
-      mockFs({
-        'build.json': fs.readFileSync(path.join(fixturePath, 'with-include/build.json')),
+    describe('where all includes are not defined', function() {
+      it('returns an array of undefined module names and includes', function() {
+        mockFs({
+          'build.json': fs.readFileSync(path.join(fixturePath, 'with-include/build.json')),
+        });
+
+        expect(buildLayerLint('build.json')).to.deep.equal(['foo', 'bar', 'common', 'fooMod']);
       });
-
-      expect(buildLayerLint('build.json')).to.deep.equal(['fooMod', 'foo', 'bar', 'common']);
     });
-  });
 
-  describe('given a build.json with includes where all includes are defined', function() {
-    it('returns an empty array', function() {
-      mockFs({
-        'build.json': fs.readFileSync(path.join(fixturePath, 'simple/build.json')),
-        'foo.js': 'foo',
-        'bar.js': 'bar',
-        'fooBar.js': 'fooBar'
+    describe('where all includes are defined', function() {
+      it('returns an empty array', function() {
+        mockFs({
+          'build.json': fs.readFileSync(path.join(fixturePath, 'with-include/build.json')),
+          'foo.js': 'foo',
+          'bar.js': 'bar',
+          'common.js': 'common',
+          'fooMod.js': 'fooMod'
+        });
+
+        expect(buildLayerLint('build.json')).to.deep.equal([]);
       });
-
-      expect(buildLayerLint('build.json')).to.deep.equal([]);
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -164,4 +164,31 @@ describe('buildLayerLint', function() {
       });
     });
   });
+
+  describe('given a build.js with excludes', function() {
+
+    describe('where all excludes are not defined', function() {
+      it('returns an array of undefined excludes', function() {
+        mockFs({
+          'build.json': fs.readFileSync(path.join(fixturePath, 'with-exclude/build.json')),
+          'foo.js': 'foo'
+        });
+
+        expect(buildLayerLint('build.json')).to.deep.equal(['jquery', 'common']);
+      });
+    });
+
+    describe('where all excludes are defined', function() {
+      it('returns an empty array', function() {
+        mockFs({
+          'build.json': fs.readFileSync(path.join(fixturePath, 'with-exclude/build.json')),
+          'foo.js': 'foo',
+          'jquery.js': 'jquery',
+          'common.js': 'common'
+        });
+
+        expect(buildLayerLint('build.json')).to.deep.equal([]);
+      });
+    });
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -108,4 +108,47 @@ describe('buildLayerLint', function() {
       expect(buildLayerLint('build.json', 'forks')).to.deep.equal([]);
     });
   });
+
+  describe('given a build.js with includes', function() {
+    it('reads it when it exists', function() {
+      mockFs({
+        'build.json': fs.readFileSync(path.join(fixturePath, 'with-include/build.json'))
+      });
+
+      expect(function() {
+        buildLayerLint('build.json');
+      }).to.not.throw(Error);
+    });
+
+    it('throws an error when it does not exist', function() {
+      mockFs();
+
+      expect(function() {
+        buildLayerLint('build.json');
+      }).to.throw(/no such file or directory/);
+    });
+  });
+
+  describe('given a build.json with includes where all includes are not defined', function() {
+    it('returns an array of undefined module names and includes', function() {
+      mockFs({
+        'build.json': fs.readFileSync(path.join(fixturePath, 'with-include/build.json')),
+      });
+
+      expect(buildLayerLint('build.json')).to.deep.equal(['fooMod', 'foo', 'bar', 'common']);
+    });
+  });
+
+  describe('given a build.json with includes where all includes are defined', function() {
+    it('returns an empty array', function() {
+      mockFs({
+        'build.json': fs.readFileSync(path.join(fixturePath, 'simple/build.json')),
+        'foo.js': 'foo',
+        'bar.js': 'bar',
+        'fooBar.js': 'fooBar'
+      });
+
+      expect(buildLayerLint('build.json')).to.deep.equal([]);
+    });
+  });
 });


### PR DESCRIPTION
Spent some time tracking down a build error yesterday because I had ractive-partials instead of rap in the include for the common bundle. Got to pre before this failed, so it would be nice for this to fail in singularity.

Was thinking about doing excludes too, would be easy enough, but wasn't completely sure about it.

Also, worth noting that grunt-behance has fixed versioning for this so that would need to be updated for this to do something.